### PR TITLE
Add terminology guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ programming in style.
 ## Collaboration
 
 * [Code Review](code-review/README.md)
+* [Terminology](terminology/README.md)
 
 ## Engineering
 

--- a/terminology/README.md
+++ b/terminology/README.md
@@ -1,0 +1,16 @@
+# Terminology
+
+The language we use has power. Being as concise and descriptive as possible
+helps to lessen ambiguity. This leads to shared understanding and better
+outcomes.
+
+## Terms
+
+* Use `blocklist`, and not `blacklist`.
+* Use `allowlist`, and not `whitelist`.
+* Avoid using `master` and `slave`. 
+  * For git, use `main`.
+  * For databases, use `write database` and `read replica`.
+  * For other scenarios, use terms such as `parent` and `child` or `leader` and
+    `follower`. Be mindful of scenarios where other commands will create
+language like, sending `kill` signals to `children`.


### PR DESCRIPTION
Borrowed from thoughtbot/guides. I kept the engineering specific pieces
and removed the more general terminology guides to place in notion for
the rest of the team.