### PR TITLE
Start a React guide / Prefer defaultValue at the field level as opposed to useForm defaultValues

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ programming in style.
 ## Engineering
 
 * [Rails](rails/README.md)
+* [React](react/README.md)
 * [Responsibilities & Rituals](rituals/README.md)
 
 ## Protocols

--- a/react/README.md
+++ b/react/README.md
@@ -1,0 +1,7 @@
+# React
+
+* Prefer setting default values for form fields when using [react-hook-form] at
+  the individual input level instead of using the `useForm`'s `defaultValues`
+  option.
+
+[react-hook-form]: https://react-hook-form.com/api/useform


### PR DESCRIPTION
Start a React guide.

First guideline - prefer setting form default values at the input level as opposed to the `defaultValues` configuration option.

## Example

### Bad

```tsx
const MyForm: React.FC = (): React.ReactElement => {
  const { register } = useForm({
    defaultValues: {
      myField: "Some default",
    },
  });

  return (
    <form>
      <label for="myField">My field</label>
      <input type="text" {...register("myField")} />
    </form>
  );
};

```

### Preferred

```tsx
const MyForm: React.FC = (): React.ReactElement => {
  const { register } = useForm();

  return (
    <form>
      <label for="myField">My field</label>
      <input defaultValue="Some default" type="text" {...register("myField")} />
    </form>
  );
};
```

## Why

When using `defaultValues` we end up in situations where our custom field handlers are not able to set a default properly. Take the `DateField` component in `Buoy` for example. The field accepts dates in the format of `MM/DD/YYYY` and then converts them to ISO8601 for use internally. When provided a date from the server in ISO8601 format, it fails to properly coerce the value from ISO8601 to `MM/DD/YYYY` when using the `defaultValues` configuration since we have no way of accessing the `defaultValues` for the form. If we pass it in as a prop, we can take it, massage it properly, and set our default.

Another example of this is when working with react-select. Default values for `react-select` should be the entire option that is selected, and NOT just the value of the option. If we handled this via `useForm` and `defaultValues`, then we need to expose the logic of how our individual selects work at the form level breaking encapsulation.

## TODO

It would be nice if we could write up our own eslint rule for something like this.