### PR TITLE
Use Terraform to update roles and permissions

### DIFF
--- a/authorization/README.md
+++ b/authorization/README.md
@@ -3,7 +3,8 @@
 ## Permission Changes
 
 - Use the `verb:noun` naming convention. IE: `manage:donor` `read:donor`
-- Keep permissions in the [DevOps] repository up to date.
+- Don't update roles or permissions directly within Auth0.
+- Use Terraform in the [DevOps] repository to update permissions.
 - Ensure the [Permissions Matrix] is up to date.
 - Ensure permissions are updated in all Auth0 tenants.
   - Current tenants include: Development, Staging, Validation and Production


### PR DESCRIPTION
Now that we have moved our Auth0 configuration to Terraform, lets point
engineers to it when updating roles and permissions.