### PR TITLE
Introduce Testing with RSpec guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ do not cover your particular topic, review their guides for guidance.
 
 * [Rails](rails/README.md)
 * [React](react/README.md)
+* [Testing with RSpec](testing-rspec/README.md)
 
 ## Protocols
 

--- a/testing-rspec/README.md
+++ b/testing-rspec/README.md
@@ -1,0 +1,79 @@
+# Testing with RSpec
+
+- Avoid the `private` keyword in specs.
+- Avoid checking boolean equality directly. Instead, write predicate methods and
+  use appropriate matchers. [Example](predicate_tests_spec.rb).
+- Prefer `eq` to `==` in RSpec.
+- Separate setup, exercise, verification, and teardown phases with newlines. [Four-Phase Test]
+- Use RSpec's [`expect` syntax].
+- Use RSpec's [`allow` syntax] for method stubs.
+- Use `not_to` instead of `to_not` in RSpec expectations.
+- Prefer the `have_css` matcher to the `have_selector` matcher in Capybara
+  assertions.
+- Avoid `any_instance` in `rspec-mocks` and `mocha`; Prefer [dependency
+  injection].
+- Avoid `its`, `specify`, and `before` in RSpec.
+- Avoid `let` (or `let!`) in RSpec. Prefer extracting helper methods, but do not
+  re-implement the functionality of `let`.
+  [Example](/testing-rspec/avoid_let_spec.rb).
+- Avoid using `subject` explicitly _inside of an_ RSpec `it` block.
+  [Example](/testing-rspec/unit_test_spec.rb).
+- Avoid using instance variables in tests.
+- Disable real HTTP requests to external services with
+  `WebMock.disable_net_connect!`.
+- Don't test private methods.
+- Use [stubs and spies] \(not mocks\) in isolated tests.
+- Use a single level of abstraction within scenarios.
+- Use an `it` example or test method for each execution path through the method.
+- Use [assertions about state] for incoming messages.
+- Use stubs and spies to assert you sent outgoing messages.
+- Use a [Fake] to stub requests to external services.
+- Use integration tests to execute the entire app.
+- Use non-[SUT] methods in expectations when possible.
+
+[`expect` syntax]:
+http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
+[`allow` syntax]: https://github.com/rspec/rspec-mocks#method-stubs
+[dependency injection]: http://en.wikipedia.org/wiki/Dependency_injection
+[`delayed::job` matcher]: https://gist.github.com/3186463
+[stubs and spies]: http://robots.thoughtbot.com/post/159805295/spy-vs-spy
+[assertions about state]:
+https://speakerdeck.com/skmetz/magic-tricks-of-testing-railsconf?slide=51
+[fake]: http://robots.thoughtbot.com/post/219216005/fake-it
+[sut]: http://xunitpatterns.com/SUT.html
+[Four-Phase Test]: https://thoughtbot.com/blog/four-phase-test
+
+## Acceptance Tests
+
+[Sample](acceptance_test_spec.rb)
+
+- Avoid scenario titles that add no information, such as "successfully."
+- Avoid scenario titles that repeat the feature title.
+- Place helper methods for feature specs directly in a top-level `Features`
+  module.
+- Use Capybara's `feature/scenario` DSL.
+- Use names like `ROLE_ACTION_spec.rb`, such as `user_changes_password_spec.rb`,
+  for feature spec file names.
+- Use only one `feature` block per feature spec file.
+- Use scenario titles that describe the success and failure paths.
+- Use spec/features directory to store feature specs.
+- Use spec/support/features for support code related to feature specs.
+
+## Unit Tests
+
+[Sample](unit_test_spec.rb)
+
+- Don't prefix `it` block descriptions with `should`. Use [Imperative mood]
+  instead.
+- Use `subject` blocks to define objects for use in one-line specs.
+  [Example](unit_test_spec.rb#6).
+- Put one-liner specs at the beginning of the outer `describe` blocks.
+- Use `.method` to describe class methods and `#method` to describe instance
+  methods.
+- Use `context` to describe testing preconditions.
+- Use `describe '#method_name'` to group tests by method-under-test
+- Use a single, top-level `describe ClassName` block.
+- Order validation, association, and method tests in the same order that they
+  appear in the class.
+
+[imperative mood]: http://en.wikipedia.org/wiki/Imperative_mood

--- a/testing-rspec/avoid_let_spec.rb
+++ b/testing-rspec/avoid_let_spec.rb
@@ -1,0 +1,52 @@
+# Not recommended
+describe ReportPolicy do
+  let(:report_id) { 2 }
+  let(:report_policy) do
+    ReportPolicy.new(
+      User.new(report_ids: [1,2]),
+      Report.new(id: report_id)
+    )
+  end
+
+  describe "#allowed?" do
+    subject { report_policy.allowed? }
+    
+    context "when user has access to report" do
+      it { should be true }
+    end
+
+    context "when user does not have access to report" do
+      let(:report_id) { 3 }
+      
+      it { should be false }
+    end
+  end
+end
+
+# Recommended
+describe ReportPolicy do
+  describe "#allowed?" do
+    context "when user has access to report" do
+      it "returns true" do
+        policy = build_policy(report_id: 2, allowed_report_ids: [1, 2])
+
+        expect(policy).to be_allowed
+      end
+    end
+
+    context "when user does not have access to report" do
+      it "returns false" do
+        policy = build_policy(report_id: 3, allowed_report_ids: [1, 2])
+
+        expect(policy).not_to be_allowed
+      end
+    end
+  end
+
+  def build_policy(report_id:, allowed_report_ids:)
+    user = instance_double("User", report_ids: allowed_report_ids)
+    report = instance_double("Report", id: report_id)
+
+    ReportPolicy.new(user, report)
+  end
+end

--- a/testing-rspec/predicates_tests_spec.rb
+++ b/testing-rspec/predicates_tests_spec.rb
@@ -1,0 +1,17 @@
+# Class under test:
+
+class Thing
+  def awesome?
+    true
+  end
+end
+
+# RSpec test:
+
+describe Thing, "#awesome?" do
+  it "is true" do
+    thing = Thing.new
+
+    expect(thing).to be_awesome
+  end
+end

--- a/testing-rspec/unit_test_spec.rb
+++ b/testing-rspec/unit_test_spec.rb
@@ -1,0 +1,46 @@
+describe SomeClass do
+  context "when defining a subject" do
+    # GOOD
+    # it's okay to define a `subject` here:
+    subject { "foo" }
+
+    it { should eq "foo" }
+  end
+
+  context "when using an explicit subject" do
+    subject { "foo" }
+
+    it "should equal foo" do
+      # BAD
+      # although it's valid RSpec code and this test passes,
+      # it's not okay to use `subject` here:
+      expect(subject).to eq "foo"
+    end
+  end
+
+  describe '.some_class_method' do
+    it 'does something' do
+      # ...
+    end
+  end
+
+  describe '#some_instance_method' do
+    it 'does something' do
+      expect(something).to eq 'something'
+    end
+  end
+
+  describe '#another_instance_method' do
+    context 'when in one case' do
+      it 'does something' do
+        # ...
+      end
+    end
+
+    context 'when in other case' do
+      it 'does something else' do
+        # ...
+      end
+    end
+  end
+end


### PR DESCRIPTION
Similar to https://github.com/BuoySoftware/guides/pull/36 this pulls
from the thoughtbot [Testing with RSpec] guide with modification for our
usage.

[Testing with RSpec]: https://github.com/thoughtbot/guides/tree/main/testing-rspec