### PR TITLE
Update guides for automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ do not cover your particular topic, review their guides for guidance.
 
 ## Testing
 
-- [Cypress](cypress/README.md)
+- [Automation](automation/README.md)
 
 ## Tools
 

--- a/automation/README.md
+++ b/automation/README.md
@@ -1,6 +1,5 @@
-# Cypress
+# Shared
 
-- Try to follow the [best practices] outlined by Cypress.
 - Use the [Page Object Pattern] when designing tests.
   - We try to encapsulate all modules into one (or more) module(s) for each widget.
     Such as the ReceptionWidget, we have a ScreeningPage and RegistrationPage that
@@ -9,17 +8,33 @@
 - Use PascalCase when creating new files ex. => `Login.spec.ts`, `PaymentsModal.ts`
 - Prefer [fixtures] over hard coded values.
 - Use [i18n] (where applicable) instead of hard-coding text, buttons, inputs, form fields, etc.
-- Assertions:
-  - Prefer [.should() or .and()] with callback over .then() for assertions.
-  - High level assertions (such as business logic) should be kept in a spec or
-    helper file, low-level assertions such as i18n are acceptable in page objects.
-- Any element you use should have a `data-testid` selector attached to it,
+- Any element you use should have a `data-testid` (`testID` for detox) selector attached to it,
   if not, prioritize working with a dev (or add it yourself) to remedy the issue.
-- Don't try to automate every test, these are some good guidelines to follow from [SmartBear].
 - [Test structure] should follow the pattern of `describe()`, `context()` and `it()`
   - We'll want this pattern to be readable by anyone outside of the engineering team,
     such as (Physicals Widget - Vitals Review - phys sub cannot select `acceptable? no`
     when the donor has acceptable vitals)
+  - Prefer to use present tense in [test titles]
+- Don't try to automate every test, these are some good guidelines to follow from [SmartBear].
+
+# Cypress
+
+[Cypress Documentation]
+
+- A few practices that we follow that Cypress does not recommend:
+  - Using the Page Object Pattern
+  - Tightly coupling tests (e2e suites only)
+    - Example: We want to test the entire flow of a donor's journey. If we
+      were to mock this data between tests we wouldn't be testing the system
+      as a cohesive unit.
+- Assertions:
+  - Prefer [.should() or .and()] with callback over .then() for assertions.
+  - High level assertions (such as business logic) should be kept in a spec or
+    helper file, low-level assertions such as i18n are acceptable in page objects.
+
+# Detox
+
+[Detox Documentation]
 
 [page object pattern]: https://www.toolsqa.com/cypress/page-object-pattern-in-cypress/
 [fixtures]: https://www.toolsqa.com/cypress/fixtures-in-cypress/
@@ -28,3 +43,6 @@
 [smartbear]: https://smartbear.com/learn/automated-testing/best-practices-for-automation/
 [best practices]: https://docs.cypress.io/guides/references/best-practices
 [test structure]: https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Test-Structure
+[detox documentation]: https://wix.github.io/Detox/docs/introduction/getting-started
+[cypress documentation]: https://docs.cypress.io/guides/overview/why-cypress
+[test titles]: https://www.betterspecs.org/#should


### PR DESCRIPTION
New guides:
- Prefer to use present tense in [test titles] https://www.betterspecs.org/#should

I also explicitly referenced the best practices that we do not follow from Cypress