### PR TITLE
Add input argument entry for GraphQL mutatations

### DIFF
--- a/graphql/README.md
+++ b/graphql/README.md
@@ -4,17 +4,19 @@ A guide for building great GraphQL servers and clients.
 
 ## Best Practices
 
-* Use `find` prefix when creating a field to lookup a single data set, ie `findDonation(id: ID!)` vs `donation(id: ID!)`
-[Issue 3448](https://github.com/BuoySoftware/BuoyRails/issues/3448)
-* Avoid accepting overloaded or multiple arguments for a field, ie `donor(id: ID, email: String)`, create multiple fields instead, ie `findDonorByID(id: ID!)` and `findDonorByEmail(email: String!)`
-* Use the [GraphQL Dataloader] pattern to eager load associations and avoid n + 1
+- Use `find` prefix when creating a field to lookup a single data set, ie `findDonation(id: ID!)` vs `donation(id: ID!)`
+  [Issue 3448](https://github.com/BuoySoftware/BuoyRails/issues/3448)
+- Avoid accepting overloaded or multiple arguments for a field, ie `donor(id: ID, email: String)`, create multiple fields instead, ie `findDonorByID(id: ID!)` and `findDonorByEmail(email: String!)`
+- Use the [GraphQL Dataloader] pattern to eager load associations and avoid n + 1
   queries. For example, [GraphQL Batch].
+- Use a single argument called input when creating mutations, following the
+  Relay spec. [Example](graphql/examples/mutation_input.graphl)
 
 ### Apollo
 
-* Always include a type's ID field if it has one for caching.
-* Colocate queries and mutations in the components they are used
-* [Colocate fragments] to split up query logic between components. 
+- Always include a type's ID field if it has one for caching.
+- Colocate queries and mutations in the components they are used
+- [Colocate fragments] to split up query logic between components.
 
 ## Learning
 

--- a/graphql/examples/mutation_input.graphql
+++ b/graphql/examples/mutation_input.graphql
@@ -1,0 +1,23 @@
+"""
+Bad
+"""
+type Mutation {
+  addPodcast(
+    title: String!
+    url: String!
+    description: String!
+  ): AddPodcastPayload
+}
+
+"""
+Good
+"""
+input PodcastAttributes {
+  title: String!
+  url: String!
+  description: String!
+}
+
+type Mutation {
+  addPodcast(input: PodcastAttributes!): AddPodcastPayload
+}


### PR DESCRIPTION
The Relay specification follows the pattern where mutations have a single argument called input. This allows a predictable pattern across mutations.

Further reading:

https://blog.logrocket.com/robust-graphql-mutations-the-relay-way/

https://blog.logrocket.com/making-a-graphql-server-compatible-with-relay/ 

https://graphql-ruby.org/type_definitions/input_objects.html 

https://graphql.org/graphql-js/mutations-and-input-types/