### PR TITLE
Updates to the authorization guide

### DIFF
--- a/authorization/README.md
+++ b/authorization/README.md
@@ -3,6 +3,8 @@
 ## Permission Changes
 
 - Use the `verb:noun` naming convention. IE: `manage:donor` `read:donor`
+- Use the `manage` verb to represent all actions for the given noun. IE: `manage:donor`
+  represents `create:donor` `read:donor` `update:donor` `delete:donor`.
 - Don't update roles or permissions directly within Auth0.
 - Use Terraform in the [DevOps] repository to update permissions.
 - Ensure the [Permissions Matrix] is up to date.
@@ -26,3 +28,19 @@
 [DevOps]: https://github.com/BuoySoftware/DevOps
 [Four Eyes Principle]: https://www.openriskmanual.org/wiki/Four_Eyes_Principle
 [Permissions Matrix]: https://www.notion.so/0b902ab8e86e4f158772d2939837365e?v=f84d5f6e8cd04ff3a3c2b1b41c53404c
+
+## Pundit Policies
+
+- Ensure the `manage?` permission represents all actions for the given noun.
+  [Example Pundit Policy].
+- Ensure `master_grant?` represents all actions for all nouns.
+  [Example Pundit Policy].
+
+[Example Pundit Policy]: /authorization/example_policy.rb
+
+## CASL
+
+- `manage:noun` and `manage:all` are supported out of the box.
+  [CASL Basics].
+
+[CASL Basics]: https://casl.js.org/v6/en/guide/intro#basics

--- a/authorization/example_policy.rb
+++ b/authorization/example_policy.rb
@@ -1,0 +1,21 @@
+class ExamplePolicy < ApplicationPolicy
+  def manage?
+     master_grant? || grant?("manage:example")
+  end
+
+  def create?
+     manage? || grant?("create:example")
+  end
+
+  def read?
+     manage? || grant?("read:example")
+  end
+
+  def update?
+     manage? || grant?("update:example")
+  end
+
+  def delete?
+     manage? || grant?("delete:example")
+  end
+end


### PR DESCRIPTION
This catches our authorization guide up to how we have historically approached permissions.

- We should consider renaming the `master_grant` to be inline with our our terminology guide, https://github.com/BuoySoftware/guides/blob/main/terminology/README.md
