### PR TITLE
Update GraphQL Best Practices

### DIFF
--- a/graphql/README.md
+++ b/graphql/README.md
@@ -4,8 +4,8 @@ A guide for building great GraphQL servers and clients.
 
 ## Best Practices
 
-- Use `find` prefix when creating a field to lookup a single data set, ie `findDonation(id: ID!)` vs `donation(id: ID!)`
-  [Issue 3448](https://github.com/BuoySoftware/BuoyRails/issues/3448)
+- Follow the [Apollo Schema Naming Conventions] document for conventions on
+  naming types, fields, and arguments.
 - Avoid accepting overloaded or multiple arguments for a field, ie `donor(id: ID, email: String)`, create multiple fields instead, ie `findDonorByID(id: ID!)` and `findDonorByEmail(email: String!)`
 - Use the [GraphQL Dataloader] pattern to eager load associations and avoid n + 1
   queries. For example, [GraphQL Batch].
@@ -22,6 +22,7 @@ A guide for building great GraphQL servers and clients.
 
 [Production Ready GraphQL](https://book.productionreadygraphql.com)
 
-[GraphQL Dataloader]: https://xuorig.medium.com/the-graphql-dataloader-pattern-visualized-3064a00f319f
-[GraphQL Batch]: https://github.com/Shopify/graphql-batch
+[Apollo Schema Naming Conventions]: https://www.apollographql.com/docs/technotes/TN0002-schema-naming-conventions/
 [Colocate fragments]: https://www.apollographql.com/docs/react/data/fragments/#colocating-fragments
+[GraphQL Batch]: https://github.com/Shopify/graphql-batch
+[GraphQL Dataloader]: https://xuorig.medium.com/the-graphql-dataloader-pattern-visualized-3064a00f319f


### PR DESCRIPTION
* Remove guidance on prefixing fields with `find` for looking up a single item.
* Replace with guidance to follow the Apollo Schema Naming Conventions.
https://www.apollographql.com/docs/technotes/TN0002-schema-naming-conventions/#field-names