### PR TITLE
Adapt linting rules to our current style

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -607,7 +607,12 @@ Lint/RaiseException:
 
 Layout/ArgumentAlignment:
   Enabled: true
-  EnforcedStyle: "with_fixed_indentation"
+  EnforcedStyle: "with_first_argument"
+
+Layout/FirstArgumentIndentation:
+  Enabled: true
+  Exclude:
+    - "**/*.erb"
 
 Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: true


### PR DESCRIPTION
Try to minimize linting errors when writing ERB in what seems to be our current preferred style.

Before

<img width="1083" alt="Screenshot 2023-10-11 at 11 08 16 AM" src="https://github.com/BuoySoftware/guides/assets/11340522/391b81d4-7a18-4f0e-aae9-5be52292ff57">

After

<img width="1083" alt="Screenshot 2023-10-11 at 11 07 59 AM" src="https://github.com/BuoySoftware/guides/assets/11340522/77273546-ec5f-4081-b10d-08e4078f8fb9">