### PR TITLE
Add conditional testing guide for playwright 

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -43,6 +43,7 @@
 [Playwright Documentation]
 
 - Try to keep tests independent of each-other. If that is not easily attainable, run tests in [serial] mode or combine flows into one test.
+- Use [test.skip(conditional, message)] when a test is dependent on a feature flag (or multiple flags) being enabled.
 
 # Resources
 
@@ -62,3 +63,4 @@
 [try not to nest callbacks]: https://glebbahmutov.com/cypress-examples/recipes/concat-labels.html
 [many examples]: https://glebbahmutov.com/cypress-examples
 [serial]: https://playwright.dev/docs/test-parallel#serial-mode
+[test.skip(conditional, message)]: https://playwright.dev/docs/api/class-test#test-skip-3

--- a/automation/README.md
+++ b/automation/README.md
@@ -43,7 +43,7 @@
 [Playwright Documentation]
 
 - Try to keep tests independent of each-other. If that is not easily attainable, run tests in [serial] mode or combine flows into one test.
-- Use [test.skip(conditional, message)] when a test is dependent on a feature flag (or multiple flags) being enabled.
+- Use [test.skip(conditional, message)] for conditional executions of a test. This can be used for tests that rely on a feature flag being enabled.
 
 # Resources
 


### PR DESCRIPTION
Related slack thread https://buoy-software.slack.com/archives/C02KX2QKNRL/p1701112540561909

Instead of using `if` blocks as we did with Cypress, we should use `test.skip()`