### PR TITLE
Update guides for automation

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -6,16 +6,20 @@
     will instantiate all of the submodules in order to keep our imports and complexity
     in the test spec to a minimum.
 - Use PascalCase when creating new files ex. => `Login.spec.ts`, `PaymentsModal.ts`
-- Prefer [fixtures] over hard coded values.
+- Use snake_case when creating new folders ex => `test_results`
 - Use [i18n] (where applicable) instead of hard-coding text, buttons, inputs, form fields, etc.
+- Prefer [fixtures] over hard coded values.
 - Prefer to find elements using test id's (`data-testid` or `testID`), or by role.
   - Use i18n to ensure the element has the correct text.
+- Prefer to use `Base` classes (forms, breadcrumbs, footers, etc) to reduce code duplication.
+  - This may not be applicable to every component. If you see a pattern in similar components, it may be worth adding a new `Base` class!
+- Prefer [early returns].
+- Prefer data generation within the test spec, avoid the [mystery guest].
+- Prefer business logic to be tested within the test spec (ie not in a PageObject or helper). Simple text assertions (ie i18n) are allowed in PageObjects.
 - [Test structure] should follow the pattern of `describe()` and `it() or test()`
   - The `it() or test()` block should be clear and concise to the intention of the test.
   - Prefer to use present tense in [test titles]
 - Don't try to automate every test, these are some good guidelines to follow from [SmartBear].
-- Prefer to use `Base` classes (forms, breadcrumbs, footers, etc) to reduce code duplication.
-  - This may not be applicable to every component. If you see a pattern in similar components, it may be worth adding a new `Base` class!
 
 # Cypress
 
@@ -30,8 +34,6 @@
 - Assertions:
   - Prefer [.should() or .and()] with callback over .then() for assertions.
   - Prefer `have.text` over `contains.text`
-  - High level assertions (such as business logic) should be kept in a spec or
-    helper file, low-level assertions such as i18n are acceptable in page objects.
 - [Try not to nest callbacks] and avoid the "pyramid of doom"
 
 # Detox
@@ -64,3 +66,5 @@
 [many examples]: https://glebbahmutov.com/cypress-examples
 [serial]: https://playwright.dev/docs/test-parallel#serial-mode
 [test.skip(conditional, message)]: https://playwright.dev/docs/api/class-test#test-skip-3
+[early returns]: https://jkm.dev/2019/08/06/return-early-return-often/
+[mystery guest]: https://thoughtbot.com/blog/mystery-guest

--- a/automation/README.md
+++ b/automation/README.md
@@ -11,12 +11,11 @@
 - Prefer [fixtures] over hard coded values.
 - Prefer to find elements using test id's (`data-testid` or `testID`), or by role.
   - Use i18n to ensure the element has the correct text.
-- Prefer to use `Base` classes (forms, breadcrumbs, footers, etc) to reduce code duplication.
+- Prefer the use of `Base` classes (forms, breadcrumbs, footers, etc) to reduce code duplication.
   - This may not be applicable to every component. If you see a pattern in similar components, it may be worth adding a new `Base` class!
-- Prefer [early returns].
 - Prefer data generation within the test spec, avoid the [mystery guest].
 - Prefer business logic to be tested within the test spec (ie not in a PageObject or helper). Simple text assertions (ie i18n) are allowed in PageObjects.
-- [Test structure] should follow the pattern of `describe()` and `it() or test()`
+- Prefer the [Test structure] of `describe()` and `it() or test()`
   - The `it() or test()` block should be clear and concise to the intention of the test.
   - Prefer to use present tense in [test titles]
 - Don't try to automate every test, these are some good guidelines to follow from [SmartBear].
@@ -44,8 +43,8 @@
 
 [Playwright Documentation]
 
-- Try to keep tests independent of each-other. If that is not easily attainable, run tests in [serial] mode or combine flows into one test.
 - Use [test.skip(conditional, message)] for conditional executions of a test. This can be used for tests that rely on a feature flag being enabled.
+- Prefer to keep tests independent of each-other. If that is not easily attainable, run tests in [serial] mode or combine flows into one test.
 
 # Resources
 
@@ -66,5 +65,4 @@
 [many examples]: https://glebbahmutov.com/cypress-examples
 [serial]: https://playwright.dev/docs/test-parallel#serial-mode
 [test.skip(conditional, message)]: https://playwright.dev/docs/api/class-test#test-skip-3
-[early returns]: https://jkm.dev/2019/08/06/return-early-return-often/
 [mystery guest]: https://thoughtbot.com/blog/mystery-guest


### PR DESCRIPTION
Rearranged a few things (use before prefer).

Added
- Use snake_case when creating new folders ex => `test_results`
- Prefer data generation within the test spec, avoid the [mystery guest].

Modified
- Prefer business logic to be tested within the test spec (ie not in a PageObject or helper). Simple text assertions (ie i18n) are allowed in PageObjects.