### PR TITLE
Add performance thresholds

### DIFF
--- a/general/README.md
+++ b/general/README.md
@@ -40,8 +40,8 @@ Style and best practices that apply to all languages and frameworks.
 
 ## Performance
 
-- Total Page Load Time should take no more than 2 seconds, and never more than 3
-- Database queries during a web request should take no more than 200ms
+- Total Page Load Time should take no more than 2 seconds, and never more than 3.
+- Database queries during a web request should take no more than 200ms.
 
 ## Organization
 

--- a/general/README.md
+++ b/general/README.md
@@ -38,6 +38,11 @@ Style and best practices that apply to all languages and frameworks.
 - Treat acronyms as words in names (`XmlHttpRequest` not `XMLHTTPRequest`), even
   if the acronym is the entire name (`class Html` not `class HTML`).
 
+## Performance
+
+- Total Page Load Time should take no more than 2 seconds, and never more than 3
+- Database queries during a web request should take no more than 200ms
+
 ## Organization
 
 - Order methods so that caller methods are earlier in the file than the methods


### PR DESCRIPTION
During the [Flag Samples as Untested performance problems Root Cause Analysis](https://www.notion.so/Root-Cause-Analysis-Performance-issue-on-Flag-as-Untested-Pending-page-10c3d71a9233804e9199c3cacc33da56#1133d71a923380d3ba1cd78c2924ca9b) we found having performance thresholds written in our guides would have helped us take a decision to refactor a slow database view in favor of a different, performant data model earlier, a potential decision we judged a bit too expensive and potentially unnecessary at the time.

Regardless of that particular RCA and action item, I think it's fair to mention some blanket rules: no page should load in more than 2 seconds, no SQL query during a web request should take more than 200ms.

I took this numbers as a first stab to initiate discussion, they may not be the best. How does this look to you?

https://app.asana.com/0/1203929356798731/1208460888232966