### PR TITLE
Use shared examples in specs instead of iterating whent testing React/Rails

### DIFF
--- a/testing-rspec/README.md
+++ b/testing-rspec/README.md
@@ -31,6 +31,7 @@
 - Use a [Fake] to stub requests to external services.
 - Use integration tests to execute the entire app.
 - Use non-[SUT] methods in expectations when possible.
+- Use shared examples to test behavior that should be the same across different implementations or configurations (for example, the React to ERB migration). Preferably, define shared examples in the same file as the specs that use them, rather than in a separate file.
 
 [`expect` syntax]: http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
 [`allow` syntax]: https://github.com/rspec/rspec-mocks#method-stubs

--- a/testing-rspec/avoid_iterating_spec.rb
+++ b/testing-rspec/avoid_iterating_spec.rb
@@ -1,0 +1,39 @@
+# Not recommended
+
+describe 'screening widget' do
+  [true, false].map do |rails_enabled|
+    context ":rails_enabled feature flag is #{rails_enabled}" do
+      before do
+        FeatureFlag.create!(name: 'rails_enabled', enabled: rails_enabled)
+      end
+
+      it 'does something' do
+        # ...
+      end
+    end
+  end
+end
+
+# Recommended
+
+describe 'screening widget' do
+  shared_examples 'does something' do
+    # ...
+  end
+
+  context ':rails_enabled feature flag is true' do
+    before do
+      FeatureFlag.create!(name: 'rails_enabled', enabled: true)
+    end
+
+    include_examples 'does something'
+  end
+
+  context ':rails_enabled feature flag is false' do
+    before do
+      FeatureFlag.create!(name: 'rails_enabled', enabled: false)
+    end
+
+    include_examples 'does something'
+  end
+end


### PR DESCRIPTION
Closes #https://github.com/BuoySoftware/guides/issues/88

- It makes it possible to run one branch and not the other.
- Avoids multi-file indirection (having one spec for Rails and the other one for React).
- Does not break stacktraces on failures (as it happens when iterating). 
- Forces the developer to write specs from the user's point of view, relying more in accessible items like text, labels, legends, etc.