### PR TITLE
General > Organization: Order methods alphabetically

### DIFF
--- a/general/README.md
+++ b/general/README.md
@@ -45,7 +45,7 @@ Style and best practices that apply to all languages and frameworks.
 
 ## Organization
 
-- Order methods so that caller methods are earlier in the file than the methods
-  they call.
-- Order methods so that methods are as close as possible to other methods they
-  call.
+- Define methods alphabetically.
+- Define class methods before instance methods.
+- Always define the `initialize` method of a class at the top of instance method
+  definitions.


### PR DESCRIPTION
## Proposal

> We should nudge engineers towards ordering methods alphabetically.

## Why Change?

The current suggestion in the guides -  which seems to be seldom followed in our code base - is to order methods by call order, reminiscent of Uncle Bob's "Step Down Rule" from his Clean Code series. That rule centers about breaking functions apart into levels (high level entry function calling upon smaller, less abstract functions to fill in the details), then ordering by call order and level of abstraction in order to minimize the vertical distance your eye has to travel to read the logic. This looks good in a book, or in a class with a single public function, like this:

```rb
class BluRayRipper
  def run
    load_disc
    rip_disc
    rename_files
  end

  private

  def load_disc
     # ...
  end
 
  def rip_disc
    # ...
  end

  def rename_files
    # ...
  end
end
```
That looks clean enough and reads beautifully in a book. But what about real life when it isn't so simple, when the public interface is 9 methods long, `private` is 40 lines below the `run` method definition, `rip_disc` calls a private method that `load_disc` also calls, etc etc etc? Or how about modules that have simple stand-alone independent methods that don't invoke other methods? How to order those?

Call order and level of abstraction break down here. It is only really applicable in a few cases.

The only ordering scheme that is applicable in _all_ cases no matter what the context is alphabetical.

> One alphabet to rule them all! 

![image](https://github.com/user-attachments/assets/28529adc-0d79-49db-aee7-866983eeefba)


## What do you think? 