### PR TITLE
Update automation guide for selectors 

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -13,8 +13,7 @@
   - `click` for links and buttons.
   - `select` for elements with options like dropdowns, radios, and checkboxes.
 - Prefer [fixtures] over hard coded values.
-- Prefer to find elements using test id's (`data-testid` or `testID`), role, or by label.
-  - Use i18n to ensure the element has the correct text.
+- Prefer to find elements using [testid, role or label](examples/selectors.md)
 - Prefer the use of `Base` classes (forms, breadcrumbs, footers, etc) to reduce code duplication.
   - This may not be applicable to every component. If you see a pattern in similar components, it may be worth adding a new `Base` class!
 - Prefer data generation within the test spec, avoid the [mystery guest].

--- a/automation/README.md
+++ b/automation/README.md
@@ -13,7 +13,7 @@
   - `click` for links and buttons.
   - `select` for elements with options like dropdowns, radios, and checkboxes.
 - Prefer [fixtures] over hard coded values.
-- Prefer to find elements using test id's (`data-testid` or `testID`), or by role.
+- Prefer to find elements using test id's (`data-testid` or `testID`), role, or by label.
   - Use i18n to ensure the element has the correct text.
 - Prefer the use of `Base` classes (forms, breadcrumbs, footers, etc) to reduce code duplication.
   - This may not be applicable to every component. If you see a pattern in similar components, it may be worth adding a new `Base` class!

--- a/automation/examples/selectors.md
+++ b/automation/examples/selectors.md
@@ -1,0 +1,40 @@
+# Selectors
+
+When finding elements on a page, it's best to have a unique and stable selector. `data-testid` is the ideal selector to use, as it is resilient to DOM changes and gives the user the exact element they intend to interact with.
+
+There are times when `data-testid` may not be needed. An element can also be found by role or by label. Due to our extensive use of i18n translations within our test automation code, we can utilize these translations when finding elements by role or label.
+
+## data-testid example
+
+```erb
+<%= button_tag "Submit", data: { testid: "submit-button" }, class: "btn-primary" %>
+```
+
+In this case, the element is identified by the `data-testid="submit-button"`, which provides a stable and unique selector that isn't affected by visual or structural changes to the DOM.
+
+## By role example
+
+```erb
+<%= button_tag "Submit", role: "button", aria: { label: "Submit" }, class: "btn-primary" %>
+```
+
+When using roles, elements can be identified by their semantic role. This example uses the `role="button"` attribute, along with the `aria-label` to describe the element's purpose. This is helpful for accessibility and can be used as a selector as well.
+
+## By label example
+
+```erb
+<%= label_tag :username, "Username" %>
+<%= text_field_tag :username, nil, id: "username", aria: { labelledby: "username" }, class: "form-control" %>
+```
+
+In this example, the element is identified by its associated label. The `aria-labelledby` attribute links the input field to the label, allowing it to be found through the label's text.
+
+## Do
+
+- Use `data-testid` for elements that are stable and need to be uniquely identified in tests.
+- Leverage role or label attributes when `data-testid` isn't necessary, especially for accessibility purposes.
+- Consider using translations in i18n-enabled applications when identifying elements by role or label.
+
+## Don't
+
+- Rely on unstable or overly generic selectors like class names or element types in tests, as these can break easily with UI changes.


### PR DESCRIPTION
Update the guide for usage on selectors. We prefer data-testid but finding by role or label is acceptable as well. 