### PR TITLE
Enable SplitStrings setting for Layout/LineLength cop

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -222,6 +222,7 @@ Layout/LineLength:
   Description: "Limit lines to 80 characters."
   StyleGuide: "https://github.com/bbatsov/ruby-style-guide#80-character-limits"
   Max: 80
+  SplitStrings: true
   Exclude:
     - config/initializers/simple_form.rb
     - db/migrate/**/*


### PR DESCRIPTION
Documentation: https://docs.rubocop.org/rubocop/cops_layout.html#configurable-attributes-layoutlinelength
