### PR TITLE
Revert "Enable SplitStrings setting for Layout/LineLength cop (#104)"

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -222,7 +222,6 @@ Layout/LineLength:
   Description: "Limit lines to 80 characters."
   StyleGuide: "https://github.com/bbatsov/ruby-style-guide#80-character-limits"
   Max: 80
-  SplitStrings: true
   Exclude:
     - config/initializers/simple_form.rb
     - db/migrate/**/*


### PR DESCRIPTION
This reverts commit 0ff639e8659d80086d8f2970df3cd2513dfb4f26.

See slack thread [here](https://buoy-software.slack.com/archives/CLF46S290/p1742594962076829)

TLDR: it seems that the recent SplitStrings update is causing rubocop to fail on CI runs :crying_cat_face: : 

![image](https://github.com/user-attachments/assets/ce735f49-19e9-457b-81da-1bd933cb1d9d)

![image](https://github.com/user-attachments/assets/cae66047-ffda-4d9b-a5ac-67ffb2411653)
 