### PR TITLE
Remove guideline to use class methods in favor of scope

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -2,7 +2,6 @@
 
 A guide for building great Rails apps.
 
-- Use def `self.method`, not the `scope :method`
 - Use methods instead of instance variables in ViewComponent templates
 - Use i18n for all text within the application.
 - Name date columns with `_on` suffixes.


### PR DESCRIPTION
Recently @Capncavedan asked me why class method, and in searching "why" I couldn't find a good answer, see https://github.com/BuoySoftware/BuoyRails/pull/13448#discussion_r2025164839. My editor suggested that shape first, and from habit I edited it back to class method but internally I liked the simple one-liner better. Both behave the same way.

We use scopes in several classes, some recently created:
```
% ag "scope :" app/models  | wc
      30     214    2307
```

We don't seem to actually prefer this guideline. That said, sometimes we'll prefer class methods, for example when with complicated filtering or for taking arguments.

Anyone against removing it?