### PR TITLE
Rubocop: Disable Style/AvoidImplicitSuper

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -6,6 +6,9 @@ AllCops:
     - db/schema.rb
     - bin/**/*
 
+inherit_from:
+  - rubocop/.style.yml
+
 plugins:
   - rubocop-performance
 

--- a/ruby/rubocop/.style.yml
+++ b/ruby/rubocop/.style.yml
@@ -1,0 +1,3 @@
+# Allows implicit `super` calls without parentheses.
+Style/AvoidImplicitSuper:
+  Enabled: false


### PR DESCRIPTION
# Why

Calls to `super` are idiomatic Ruby.

Context: https://buoy-software.slack.com/archives/CLF46S290/p1723231468170229

# What

`super` is now valid, whereas previously it was required to be: `super()`

## Pros

* We can now utilize common ruby `super` without issue
* Less code and no empty parenthesis calls (unless you explicitly don't want to forward arguments)

## Cons

* Technically less explicit
* Will automatically forward all arguments to the parent method