### PR TITLE
Use new cop name instead of obsolete one

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -325,7 +325,7 @@ Style/PerlBackrefs:
   StyleGuide: "https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers"
   Enabled: false
 
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Description: "Check the names of predicate methods."
   StyleGuide: "https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark"
   ForbiddenPrefixes:


### PR DESCRIPTION
#### Warning

This PR should only be merged once all Buoy projects depending on `ruby/.rubocop.yml` have updated to Rubocop 1.76.0+. Otherwise these projects will error out when running Rubocop.

#### Problem

We are getting the following warning in BuoyRails after merging https://github.com/BuoySoftware/BuoyRails/pull/14054:

```
Warning: The `Naming/PredicateName` cop has been renamed to `Naming/PredicatePrefix`.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-BuoySoftware-guides-main-ruby--rubocop-yml, please update it)
```

#### Solution

Use new `Naming/PredicatePrefix` cop name instead of obsolete `Naming/PredicateName`.