### PR TITLE
Remove Ruby and Rails style guidelines already enforced by RuboCop

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -26,7 +26,4 @@ A guide for building great Rails apps.
 - Use db/seeds.rb for data that is required in all environments.
 - Use dev:prime rake task for development environment seed data.
 - Prefer `cookies.signed` over `cookies` to prevent tampering.
-- Prefer `Time.current` over `Time.now`
-- Prefer `Date.current` over `Date.today`
-- Prefer `Time.zone.parse("2014-07-04 16:05:37")` over `Time.parse("2014-07-04 16:05:37")`
 - Use `ENV.fetch` for environment variables instead of `ENV[]`so that unset environment variables are detected on deploy.

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -8,11 +8,6 @@
 - Avoid bang (!) method names. Prefer descriptive names.
 - Name variables created by a factory after the factory (`user_factory` creates
   `user`).
-- Prefer nested class and module definitions over the shorthand version
-- Prefer `detect` over `find`.
-- Prefer `select` over `find_all`.
-- Prefer `map` over `collect`.
-- Prefer `reduce` over `inject`.
 - Prefer `&:method_name` to `{ |item| item.method_name }` for simple method
   calls.
 - Use `_` for unused block parameters.
@@ -20,9 +15,8 @@
 - Suffix variables holding a factory with `_factory` (`user_factory`).
 - Use `%()` for single-line strings containing double-quotes that require
   interpolation.
-- Use `?` suffix for predicate methods.
 - Prefer `def self.method`, over `class << self`.
-- Use `def` with parentheses when there are arguments. 
+- Use `def` with parentheses when there are arguments.
 - Use heredocs for multi-line strings.
 - Order class methods above instance methods.
 - Prefer method invocation over instance variables.


### PR DESCRIPTION
These rules are already checked for via `.rubocop.yml` files.

**For Ruby:**

- Nested over shorthand class definitions automated with `Style/ClassAndModuleChildren`
- `?` suffix for predicate methods automated with `Naming/PredicateName`
- `Style/CollectionMethods` takes care of:
  - `detect` over `find`
  - `select` over `find_all`
  - `map` over `collect`
  - `reduce` over `inject`

**For Rails:**

- `Date.current` over `Date.today`: `Rails/Date`
- `Rails/TimeZone` takes care of:
  - `Time.current` over `Time.now`
  - `Time.zone.parse()` over `Time.parse()`

Cursor is eager to enable cops for other suggestion we have in the READMEs and could automate, if you'd like me to accept its followup I'll do in another PR.