### PR TITLE
Update .rubocop.yml to address renamed cop warning

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -325,7 +325,7 @@ Style/PerlBackrefs:
   StyleGuide: "https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers"
   Enabled: false
 
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Description: "Check the names of predicate methods."
   StyleGuide: "https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark"
   ForbiddenPrefixes:


### PR DESCRIPTION
Started getting this: 

Warning: The `Naming/PredicateName` cop has
been renamed to `Naming/PredicatePrefix`.
(obsolete configuration found in
.rubocop-https---raw-githubusercontent-com-BuoySoftware-guides-main-ruby--rubocop-yml, please update it)