### PR TITLE
Updates Rubocop configuration to remove warning about a renamed cop

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -325,9 +325,9 @@ Style/PerlBackrefs:
   StyleGuide: "https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers"
   Enabled: false
 
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Description: "Check the names of predicate methods."
-  StyleGuide: "https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark"
+  StyleGuide: "https://github.com/bbatsov/ruby-style-guide#bool-methods-prefix"
   ForbiddenPrefixes:
     - is_
   Exclude:


### PR DESCRIPTION
Removes this warning which shows up to 3 times when running Rubocop:

```
Warning: The `Naming/PredicateName` cop has been renamed to `Naming/PredicatePrefix`.
```