### PR TITLE
docs: restore RuboCop-enforced Ruby/Rails style rules with cop references

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -29,3 +29,22 @@ A guide for building great Rails apps.
 - Use dev:prime rake task for development environment seed data.
 - Prefer `cookies.signed` over `cookies` to prevent tampering.
 - Use `ENV.fetch` for environment variables instead of `ENV[]`so that unset environment variables are detected on deploy.
+
+## Style enforced by RuboCop
+
+These conventions are checked automatically by [rubocop-buoy]; you don't need
+to police them by hand. They're documented here so the intent is explicit for
+both humans and AI agents — the "why" isn't obvious from a lint failure alone.
+
+- Prefer `Time.current` over `Time.now` and `Time.zone.parse("2014-07-04 16:05:37")`
+  over `Time.parse("2014-07-04 16:05:37")`. The zone-aware methods respect the
+  application's configured time zone; the bare `Time` methods use the server's
+  system zone, which silently produces wrong results across environments.
+  ([`Rails/TimeZone`], `EnforcedStyle: flexible`)
+- Prefer `Date.current` over `Date.today`. `Date.today` reads the server's
+  system date rather than the application time zone, so it can be off by a day.
+  ([`Rails/Date`])
+
+[rubocop-buoy]: https://github.com/BuoySoftware/rubocop-buoy
+[`Rails/TimeZone`]: https://docs.rubocop.org/rubocop-rails/cops_rails.html#railstimezone
+[`Rails/Date`]: https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsdate

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -28,11 +28,27 @@ both humans and AI agents — the "why" isn't obvious from a lint failure alone.
 - Name predicate methods with a `?` suffix and no `is_` prefix (`even?`, not
   `is_even`). The `?` already signals a boolean answer, so the prefix is
   redundant. ([`Naming/PredicatePrefix`])
+- Prefer `&:method_name` over `{ |item| item.method_name }` for a block that
+  just calls one method. The symbol-to-proc form is shorter and reads as the
+  intent. ([`Style/SymbolProc`])
+- Avoid parallel assignment (`one, two = 1, 2`). Assigning on separate lines is
+  clearer and avoids surprises with mismatched left- and right-hand sides.
+  ([`Style/ParallelAssignment`])
+- Prefix unused block arguments and parameters with `_` (`_unused`), or use a
+  bare `_`. The underscore documents "intentionally ignored" so a genuinely
+  unused variable doesn't read like a mistake. ([`Lint/UnusedBlockArgument`])
+- Use `def` with parentheses when the method takes arguments. Parentheses make
+  the signature unambiguous and keep definitions consistent.
+  ([`Style/MethodDefParentheses`])
 
 [rubocop-buoy]: https://github.com/BuoySoftware/rubocop-buoy
 [`Style/ClassAndModuleChildren`]: https://docs.rubocop.org/rubocop/cops_style.html#styleclassandmodulechildren
 [`Style/CollectionMethods`]: https://docs.rubocop.org/rubocop/cops_style.html#stylecollectionmethods
 [`Naming/PredicatePrefix`]: https://docs.rubocop.org/rubocop/cops_naming.html#namingpredicateprefix
+[`Style/SymbolProc`]: https://docs.rubocop.org/rubocop/cops_style.html#stylesymbolproc
+[`Style/ParallelAssignment`]: https://docs.rubocop.org/rubocop/cops_style.html#styleparallelassignment
+[`Lint/UnusedBlockArgument`]: https://docs.rubocop.org/rubocop/cops_lint.html#lintunusedblockargument
+[`Style/MethodDefParentheses`]: https://docs.rubocop.org/rubocop/cops_style.html#stylemethoddefparentheses
 
 ## Bundler
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -11,6 +11,29 @@
 
 [bundler binstubs]: https://github.com/sstephenson/rbenv/wiki/Understanding-binstubs
 
+## Style enforced by RuboCop
+
+These conventions are checked automatically by [rubocop-buoy]; you don't need
+to police them by hand. They're documented here so the intent is explicit for
+both humans and AI agents — the "why" isn't obvious from a lint failure alone.
+
+- Prefer nested class and module definitions over the compact `Foo::Bar`
+  shorthand. Nesting keeps `Module.nesting` and constant lookup predictable, so
+  references resolve against the enclosing namespace as written.
+  ([`Style/ClassAndModuleChildren`], `EnforcedStyle: nested`)
+- Prefer the shorter, more idiomatic `Enumerable` names over their aliases —
+  `detect` over `find`, `select` over `find_all`, `map` over `collect`, and
+  `reduce` over `inject`. Picking one name per operation keeps the codebase
+  consistent and greppable. ([`Style/CollectionMethods`])
+- Name predicate methods with a `?` suffix and no `is_` prefix (`even?`, not
+  `is_even`). The `?` already signals a boolean answer, so the prefix is
+  redundant. ([`Naming/PredicatePrefix`])
+
+[rubocop-buoy]: https://github.com/BuoySoftware/rubocop-buoy
+[`Style/ClassAndModuleChildren`]: https://docs.rubocop.org/rubocop/cops_style.html#styleclassandmodulechildren
+[`Style/CollectionMethods`]: https://docs.rubocop.org/rubocop/cops_style.html#stylecollectionmethods
+[`Naming/PredicatePrefix`]: https://docs.rubocop.org/rubocop/cops_naming.html#namingpredicateprefix
+
 ## Bundler
 
 - Specify the [Ruby version] to be used on the project in the `Gemfile`.


### PR DESCRIPTION
## Context
Our Ruby and Rails style guides used to list rules like "prefer `detect` over `find`", "prefer `&:method_name`", and "prefer `Time.current` over `Time.now`". Two PRs stripped them: #120 removed rules explicitly because `rubocop-buoy` enforces them, and #117 ("Simplify Ruby guides") removed a larger Ruby set, some of which are also RuboCop-enforced.

## Problem
Removing them lost the *why*. A contributor (or an AI agent) who trips a cop sees a lint failure but no rationale, and the guides no longer explain which conventions we hold or why they matter. The ask: keep automation-covered rules documented, with a link to the enforcing cop and the reason behind each rule.

## Solution
Restore the automation-covered rules under a new "Style enforced by RuboCop" subsection in each guide. Each rule links to the cop's RuboCop docs and states why it exists. Every mapping was verified against our actual `rubocop-buoy` config so the guidance matches what's enforced.

- **ruby/README.md**
  - From #120: `Style/ClassAndModuleChildren`, `Style/CollectionMethods`, `Naming/PredicatePrefix`.
  - From #117 (verified enforced): `Style/SymbolProc`, `Style/ParallelAssignment`, `Lint/UnusedBlockArgument`, `Style/MethodDefParentheses`.
- **rails/README.md**
  - From #120: `Rails/TimeZone`, `Rails/Date`.

Scope note: #117 also dropped rules that are *not* RuboCop-enforced (avoid ternaries, use heredocs, order class methods above instance methods, etc.). Those were a deliberate guide simplification, not automation coverage, so they're intentionally left out of this PR.

Accuracy notes surfaced while verifying:
- `Naming/PredicatePrefix` replaces the renamed `Naming/PredicateName` cited in #120's message.
- `Style/CollectionMethods` prefers `detect` here per our `PreferredMethods` override (the cop's own default is the opposite).

## Test plan
- [x] Cop names and doc anchors verified against docs.rubocop.org (current names, not the pre-rename ones).
- [x] Each rule cross-checked against our `rubocop-buoy` config — enabled state, `EnforcedStyle`, and `PreferredMethods` overrides all match.
- [x] The #117 candidates were checked against the config; only the four that actually produce offenses (SymbolProc, ParallelAssignment, UnusedBlockArgument, MethodDefParentheses) were included. Non-firing candidates (e.g. `Style/IfUnlessModifier`, which actually favors the opposite) were excluded.
- [ ] Reviewer: confirm the "Style enforced by RuboCop" framing reads well alongside the existing inline `Rails/ActionOrder` reference.

No ticket — guide maintenance.