### PR TITLE
docs: restore React and Jest guides, modernized to current stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ do not cover your particular topic, review their guides for guidance.
 ## Frameworks and platforms
 
 - [Rails](rails/README.md)
+- [React](react/README.md)
 - [Testing with RSpec](testing-rspec/README.md)
+- [Testing with Jest](testing-jest/README.md)
 
 ## Protocols
 

--- a/react/README.md
+++ b/react/README.md
@@ -1,0 +1,7 @@
+# React
+
+- Prefer setting default values for form fields when using [react-hook-form] at
+  the individual input level instead of using `useForm`'s `defaultValues`
+  option.
+
+[react-hook-form]: https://react-hook-form.com/docs/useform

--- a/testing-jest/README.md
+++ b/testing-jest/README.md
@@ -1,0 +1,19 @@
+# Testing with Jest
+
+- Use [eslint-plugin-jest] and [eslint-plugin-jest-dom] to enforce testing
+  style.
+- Use [@testing-library/jest-dom] for supplemental expectation matchers.
+- Use [React Testing Library] for testing [React](/react/) components, including
+  hooks (the standalone react-hooks-testing-library is deprecated; its
+  `renderHook` now ships with React Testing Library).
+- Use [User Event] for simulating user interactions on components under test, in
+  preference to firing raw DOM events.
+- Use [Fishery] for building factories.
+- Prefer `describe` and `it` blocks over `test` blocks.
+
+[eslint-plugin-jest]: https://github.com/jest-community/eslint-plugin-jest
+[eslint-plugin-jest-dom]: https://github.com/testing-library/eslint-plugin-jest-dom
+[@testing-library/jest-dom]: https://github.com/testing-library/jest-dom
+[react testing library]: https://github.com/testing-library/react-testing-library
+[user event]: https://github.com/testing-library/user-event
+[fishery]: https://github.com/thoughtbot/fishery


### PR DESCRIPTION
## Context
The React (`react/`) and Jest (`testing-jest/`) guides were removed in #116 as "now unused." That was accurate for the frontend stack at the time, but it no longer holds.

## Problem
React and Jest are both back in active use across our applications — React on the web and via React Native, tested with a full Jest + Testing Library + Fishery stack. With the guides gone, there's no documented convention for any of it, for humans or AI agents.

## Solution
Restore both guides, updated to match current practice rather than restoring the 2016-era content verbatim:

- **Drop the deprecated `react-hooks-testing-library`** — `renderHook` now ships with React Testing Library (v16), and the standalone package is no longer used.
- **Drop "prefer unit tests over snapshot testing"** — snapshot tests are used extensively in practice, so that rule contradicts how we actually test.
- **Add `eslint-plugin-jest-dom` and User Event**, both in active use.
- **Keep the `describe`/`it`-over-`test` convention** — it still holds.
- Re-add the top-level README links.

## Test plan
- [x] Confirmed React and Jest are current dependencies in active use before restoring the guides.
- [x] Confirmed `react-hooks-testing-library` is no longer a dependency before dropping it.
- [x] Confirmed the `describe`/`it` convention and snapshot usage match the guidance.
- [ ] Reviewer: confirm the guides should live under "Frameworks and platforms" (where they were before removal) rather than the separate "Testing" section.

Companion to #131 (RuboCop-enforced rules). No ticket — guide maintenance.