### PR TITLE
docs: add code-review etiquette practices from thoughtbot guides

### DIFF
--- a/code-review/README.md
+++ b/code-review/README.md
@@ -16,6 +16,12 @@ that covers this material from [Derek Prior at RailsConf
 - Avoid selective ownership of code. ("mine", "not mine", "yours")
 - Avoid using terms that could be seen as referring to personal traits. ("dumb",
   "stupid"). Assume everyone is intelligent and well-meaning.
+- Avoid diminishing words like "just", "simply", or "obviously". They imply the
+  thing the author missed was trivial, even when it wasn't.
+- When you disagree, explain your reasoning and suggest an alternative rather
+  than only rejecting. A bare "no" stalls the PR.
+- If you learned something from the change, say so. Review is a two-way exchange,
+  not one-directional critique.
 - Be explicit. Remember people don't always understand your intentions online.
 - Be humble. ("I'm not sure - let's look it up.")
 - Don't use hyperbole. ("always", "never", "endlessly", "nothing")
@@ -34,6 +40,9 @@ that covers this material from [Derek Prior at RailsConf
 - Explain why the code exists. ("It's like that because of these reasons. Would
   it be more clear if I rename this class/file/method/variable?")
 - Extract some changes and refactoring into future tickets/stories.
+- Include before/after screenshots or a short screencast for changes with a
+  visual result. It lets the reviewer see the outcome without checking out the
+  branch.
 - Link to the code review from the ticket/story. ("Ready for review:
   https://github.com/organization/project/pull/1")
 - Push commits based on earlier rounds of feedback as isolated commits to the
@@ -62,6 +71,13 @@ experience, refactors the existing code). Then:
   author make the final decision on alternative implementations.
 - Offer alternative implementations, but assume the author already considered
   them. ("What do you think about using a custom validator here?")
+- Avoid the "since you're at it" attitude. If you spot unrelated work, open a
+  ticket instead of expanding the scope of the PR under review.
+- Consolidate repeated style nits into a single comment, or point at the linter,
+  rather than leaving the same comment on every occurrence.
+- When using GitHub's "Add a suggestion" feature, test the suggestion first. If
+  you couldn't, say so. Be especially cautious suggesting code you got from an
+  LLM or a blog post without verifying it against this codebase.
 - Seek to understand the author's perspective.
 - Sign off on the pull request with a 👍 or "Ready to merge" comment.
 - Remember that you are here to provide feedback, not to be a gatekeeper.


### PR DESCRIPTION
## Context
Our guides are influenced by [thoughtbot's guides](https://github.com/thoughtbot/guides), which have evolved since ours were built. Comparing the two, Buoy's process and governance layer is actually richer (the standards-change ladder, pairing protocol, rituals). The one area where thoughtbot is consistently ahead is **interpersonal code-review etiquette** — the micro-practices that keep PRs small and reviews collegial.

## Problem
Our code-review guide covers the mechanics well but is silent on several friction points: scope creep during review, repeated style nits, disagreements that stall as bare rejections, and (newly relevant) suggesting unverified LLM-generated code.

## Solution
Adopt the substantive etiquette practices from thoughtbot's current guide, adapted to our voice and slotted into the existing sections:

**Everyone**
- Avoid diminishing words ("just", "simply", "obviously").
- Disagree with an alternative, not a bare rejection.
- Share what you learned from a change.

**Having your code reviewed**
- Before/after screenshots or a screencast for visual changes.

**Reviewing code**
- Scope discipline — open a ticket instead of expanding the PR under review.
- Consolidate repeated style nits into one comment / point at the linter.
- Test "Add a suggestion" edits first; be cautious suggesting LLM- or blog-sourced code without verifying it here.

Deliberately left out: thoughtbot's method-ordering-by-call-graph rule (conflicts with our alphabetical ordering) and their dated product-review guide.

## Test plan
- [x] All additions verified as genuinely absent from our current code-review guide (not duplicates of the existing "dumb/stupid", "offer alternatives", or "extract into future tickets" bullets).
- [ ] Reviewer: confirm the diminishing-words and LLM-suggestion bullets match how we actually want reviews to read.

One of a small set of thoughtbot-sync PRs (companions touch Rails FK/i18n rules). No ticket — guide maintenance.