### PR TITLE
docs: document explicit FK on_delete and i18n raise-on-missing

### DIFF
--- a/migrations/README.md
+++ b/migrations/README.md
@@ -98,6 +98,10 @@ going one release at a time instead of all the way to the final release.
 - Since there are no data, there should be no references to models.
 - If there are default values, set them in migrations.
 - [Add foreign key constraints] in migrations.
+- Set an explicit `on_delete` behavior for each foreign key (`:cascade`,
+  `:nullify`, or `:restrict`). Leaving it implicit hides what happens to child
+  rows when a parent is deleted, which is a data-integrity decision worth making
+  on purpose.
 - Add appropriate indexes.
 - When possible, avoid using ruby classes directly for an immutable migration.
 

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -98,10 +98,19 @@ going one release at a time instead of all the way to the final release.
 - Since there are no data, there should be no references to models.
 - If there are default values, set them in migrations.
 - [Add foreign key constraints] in migrations.
-- Set an explicit `on_delete` behavior for each foreign key (`:cascade`,
-  `:nullify`, or `:restrict`). Leaving it implicit hides what happens to child
-  rows when a parent is deleted, which is a data-integrity decision worth making
-  on purpose.
+- Leave `on_delete` off the foreign key. The default is `NO ACTION`, so the
+  database rejects a delete that would orphan child rows, and we express the
+  intended behavior at the model level with `dependent:` instead.
+- Avoid `on_delete: :cascade` and `on_delete: :nullify`. Both delete or mutate
+  rows the application never sees, which skips callbacks, `PaperTrail`
+  versions, and audit logging, and emits change events our downstream consumers
+  cannot attribute to anything.
+- Declare the delete behavior on the association instead. Use
+  `dependent: :restrict_with_exception` when child rows should block the
+  delete, and `dependent: :destroy` when they should go with the parent.
+- If a table genuinely needs the database to enforce the cascade — because rows
+  are removed by SQL that bypasses `ActiveRecord`, such as a data migration —
+  set `on_delete` deliberately and note why in the migration.
 - Add appropriate indexes.
 - When possible, avoid using ruby classes directly for an immutable migration.
 

--- a/rails/README.md
+++ b/rails/README.md
@@ -4,6 +4,9 @@ A guide for building great Rails apps.
 
 - Use methods instead of instance variables in ViewComponent templates
 - Use i18n for all text within the application.
+- Raise on missing translations in development and test
+  (`config.i18n.raise_on_missing_translations = true`) so a missing key fails
+  loudly instead of shipping a fallback string.
 - Name date columns with `_on` suffixes.
 - Name datetime columns with `_at` suffixes.
 - Name time columns (referring to a time of day with no date) with `_time` suffixes.


### PR DESCRIPTION
## Context
Comparing our guides against [thoughtbot's](https://github.com/thoughtbot/guides), two data-integrity practices stood out as things they document and we leave implicit.

## Problem
- Our migrations guide already requires foreign key constraints, but says nothing about `on_delete` behavior — so what happens to child rows when a parent is deleted is left to the implicit default rather than a deliberate choice.
- Our Rails guide mandates i18n for all text, but nothing makes a missing translation fail loudly, so a missing key can silently ship a fallback string.

## Solution
- **migrations/README.md** — add a bullet next to the existing FK-constraint rule: set an explicit `on_delete` behavior (`:cascade` / `:nullify` / `:restrict`) for each foreign key.
- **rails/README.md** — add a bullet next to the existing i18n mandate: raise on missing translations in dev/test via `config.i18n.raise_on_missing_translations = true`.

The i18n bullet documents existing practice rather than proposing something new — our main app already enables `raise_on_missing_translations` in development and test. Writing it down makes it the standard so the existing "use i18n for all text" mandate actually holds.

## Test plan
- [x] Confirmed the existing migrations guide already covers "add FK constraints" (so this refines it with `on_delete`, not a duplicate).
- [x] Confirmed `config.i18n.raise_on_missing_translations` is the current Rails option name and matches what our apps already set.
- [ ] Reviewer: confirm we want `on_delete` called out at the guide level vs. left to per-migration judgment.

One of a small set of thoughtbot-sync PRs (companion: code-review etiquette #133). No ticket — guide maintenance.